### PR TITLE
Version 3.0.4 - bug fixes

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## Version 3 ##
 
+### Revision 3.0.4 ###
+
+* SWAT+ Check bug fix - the the Land Use Summary tab, urban land use codes were not being looked up correctly resulting in 'NA'. Updated SWAT+ Check to refer to the name in landuse.lum, but this will require standard names in the form of "cropname_lum". More detailed warnings given when this naming lookup is unsuccessful.
+* Added default curve number values for importing SWAT+ lte projects so users do not get errors when using custom plants outside the standard table provided by SWAT+.
+
 ### Revision 3.0.3 ###
 
 * Update tiledrain.str dist parameter default to 5m; users should manually update their project values if using tile drains

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "swatplus-editor",
-	"version": "3.0.3",
+	"version": "3.0.4",
 	"description": "SWAT+ Editor",
 	"author": "Jaclyn Tech <jaclynt@tamu.edu>",
 	"private": true,

--- a/release/build/release-notes.md
+++ b/release/build/release-notes.md
@@ -1,9 +1,6 @@
-### SWAT+ Editor v3.0.3 ###
+### SWAT+ Editor v3.0.4 ###
 
-* Update tiledrain.str dist parameter default to 5m; users should manually update their project values if using tile drains
-* Bug fix in hard calibration and other pages where it wasn't allowing negative numbers
-* Bug fix in adding outflow to point source / inlets
-* Minor package updates
-* Add automatic software updates
+* SWAT+ Check bug fix - the the Land Use Summary tab, urban land use codes were not being looked up correctly resulting in 'NA'. Updated SWAT+ Check to refer to the name in landuse.lum, but this will require standard names in the form of "cropname_lum". More detailed warnings given when this naming lookup is unsuccessful.
+* Added default curve number values for importing SWAT+ lte projects so users do not get errors when using custom plants outside the standard table provided by SWAT+.
 
 _No breaking changes from v3.0.0 and later._

--- a/release/combined-installer-inno.iss
+++ b/release/combined-installer-inno.iss
@@ -1,8 +1,8 @@
 #include <idp.iss>
 
 #define SWATPlusVersion "3.0"
-#define SWATPlusPatchVersion "3"
-#define SWATPlusToolsPatchVersion "3"
+#define SWATPlusPatchVersion "4"
+#define SWATPlusToolsPatchVersion "4"
 #define QSWATPlusVersion "3.0"
 #define QSWATPlusPatchVersion "0"
 #define ToolboxVersion "2.0"

--- a/src/api/actions/get_swatplus_check.py
+++ b/src/api/actions/get_swatplus_check.py
@@ -353,8 +353,11 @@ def get_landscape(ls, ncycle, aqu):
 
 def get_landuse():
 	#get plant name for each hru
-	hru_to_crop = { c.unit: c.plantnm for c in misc.Crop_yld_aa.select() }
-	hru_name_to_area = { h.name: h.area for h in connect.Hru_con.select() }
+	#hru_to_crop = { c.unit: c.plantnm for c in misc.Crop_yld_aa.select() }
+
+	hru_cons = connect.Hru_con.select()
+	hru_to_crop = { h.name: h.hru.lu_mgt.name.replace('_lum', '') for h in hru_cons }
+	hru_name_to_area = { h.name: h.area for h in hru_cons }
 	hru_wb = waterbal.Hru_wb_aa.select().order_by(waterbal.Hru_wb_aa.unit)
 	hru_ls = losses.Hru_ls_aa.select().order_by(losses.Hru_ls_aa.unit)
 	hru_pw = plantwx.Hru_pw_aa.select().order_by(plantwx.Hru_pw_aa.unit)
@@ -366,7 +369,7 @@ def get_landuse():
 	if len(hru_wb) == len(hru_ls) and len(hru_wb) == len(hru_pw):
 		i = 0
 		for wb in hru_wb:
-			landuse = hru_to_crop.get(wb.unit, 'NA').strip()
+			"""landuse = hru_to_crop.get(wb.unit, 'NA').strip()
 
 			if landuse == 'NA':
 				try:
@@ -375,8 +378,13 @@ def get_landuse():
 					if urban is not None:
 						landuse = urban.name
 				except:
-					pass
+					pass"""
 
+			landuse = hru_to_crop.get(wb.name, '--').strip()
+			if landuse == '--':
+				warnings.append('Could not successfully lookup landuse name for {}. SWAT+ Check expects landuse.lum names in the format of "[cropname]_lum".'.format(wb.name))
+
+			landuse = '{} landuse'.format(wb.name)
 			area = hru_name_to_area.get(wb.name, 0)
 			match = rows.get(landuse, None)
 

--- a/src/api/actions/import_gis.py
+++ b/src/api/actions/import_gis.py
@@ -279,7 +279,11 @@ class GisImport(ExecutableApi):
 
 	def get_cn2(self, soil, lu):
 		lum_name = '{name}_lum'.format(name=lu)
-		ds_m = ds_lum.Landuse_lum.get(ds_lum.Landuse_lum.name == lum_name)
+		ds_m = ds_lum.Landuse_lum.get_or_none(ds_lum.Landuse_lum.name == lum_name)
+		if ds_m is None:
+			lum_default_cn2 = 5
+			ds_m = ds_lum.Landuse_lum.get(ds_lum.Landuse_lum.id == lum_default_cn2)
+		
 		cntable = ds_m.cn2
 
 		texture_map = {

--- a/src/main/static/appsettings.json
+++ b/src/main/static/appsettings.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.0.3",
+	"version": "3.0.4",
 	"swatplus": "61.0.1",
 	"python": false,
 	"pythonPath": "src/api/.venv/Scripts/python"


### PR DESCRIPTION
* SWAT+ Check bug fix - the the Land Use Summary tab, urban land use codes were not being looked up correctly resulting in 'NA'. Updated SWAT+ Check to refer to the name in landuse.lum, but this will require standard names in the form of "cropname_lum". More detailed warnings given when this naming lookup is unsuccessful.
* Added default curve number values for importing SWAT+ lte projects so users do not get errors when using custom plants outside the standard table provided by SWAT+.