### PR TITLE
Version 3.0.6 bug fixes and minor message helpers

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,15 @@
 
 ## Version 3 ##
 
+### Revision 3.0.6 ###
+
+* Fix SWAT+ Check to allow null land use management pointer in HRUs.
+* Fix importing from GIS to allow default land use management properties when user-added non-standard plant codes to swatplus_datasets.sqlite.
+* Fix printing 0 value instead of null for missing soils values.
+* Add check for empty weather generator data and issue warning both on WGN page and the run model page.
+* Add note about future support for scenario land use update decision tables, planned for editor v3.1.
+* Add manual check for updates button.
+
 ### Revision 3.0.5 ###
 
 * Bug fix in some tables with broken link to Hydrology section tables

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "swatplus-editor",
-	"version": "3.0.5",
+	"version": "3.0.6",
 	"description": "SWAT+ Editor",
 	"author": "Jaclyn Tech <jaclynt@tamu.edu>",
 	"private": true,

--- a/release/build/release-notes.md
+++ b/release/build/release-notes.md
@@ -1,8 +1,10 @@
-### SWAT+ Editor v3.0.5 ###
+### SWAT+ Editor v3.0.6 ###
 
-* Bug fix in some tables with broken link to Hydrology section tables
-* Bug fix listing HRU elements in Landscape Units section
-* Added copy function to LUM
-* Fix landuse matching bug in SWAT+ Check
+* Fix SWAT+ Check to allow null land use management pointer in HRUs.
+* Fix importing from GIS to allow default land use management properties when user-added non-standard plant codes to swatplus_datasets.sqlite.
+* Fix printing 0 value instead of null for missing soils values.
+* Add check for empty weather generator data and issue warning both on WGN page and the run model page.
+* Add note about future support for scenario land use update decision tables, planned for editor v3.1.
+* Add manual check for updates button.
 
 _No breaking changes from v3.0.0 and later._

--- a/release/combined-installer-inno.iss
+++ b/release/combined-installer-inno.iss
@@ -1,8 +1,8 @@
 #include <idp.iss>
 
 #define SWATPlusVersion "3.0"
-#define SWATPlusPatchVersion "5"
-#define SWATPlusToolsPatchVersion "5"
+#define SWATPlusPatchVersion "6"
+#define SWATPlusToolsPatchVersion "6"
 #define QSWATPlusVersion "3.0"
 #define QSWATPlusPatchVersion "0"
 #define ToolboxVersion "2.0"

--- a/src/api/actions/get_swatplus_check.py
+++ b/src/api/actions/get_swatplus_check.py
@@ -356,7 +356,7 @@ def get_landuse():
 	#hru_to_crop = { c.unit: c.plantnm for c in misc.Crop_yld_aa.select() }
 
 	hru_cons = connect.Hru_con.select()
-	hru_to_crop = { h.name: h.hru.lu_mgt.name.replace('_lum', '') for h in hru_cons }
+	hru_to_crop = { h.name: 'No Land Use' if h.hru.lu_mgt is None else h.hru.lu_mgt.name.replace('_lum', '') for h in hru_cons }
 	hru_name_to_area = { h.name: h.area for h in hru_cons }
 	hru_wb = waterbal.Hru_wb_aa.select().order_by(waterbal.Hru_wb_aa.unit)
 	hru_ls = losses.Hru_ls_aa.select().order_by(losses.Hru_ls_aa.unit)

--- a/src/api/actions/import_gis.py
+++ b/src/api/actions/import_gis.py
@@ -869,15 +869,26 @@ class GisImport(ExecutableApi):
 									plant1=plant1
 								).execute() 
 
-						lum.Landuse_lum.create(
-							name=ds_m.name,
-							plnt_com=pcom,
-							mgt=mgt_id,
-							cn2=ds_m.cn2.id,
-							cons_prac=ds_m.cons_prac.id,
-							ov_mann=ds_m.ov_mann.id,
-							cal_group=ds_m.cal_group
-						)
+						if ds_m is not None:
+							lum.Landuse_lum.create(
+								name=ds_m.name,
+								plnt_com=pcom,
+								mgt=mgt_id,
+								cn2=ds_m.cn2.id,
+								cons_prac=ds_m.cons_prac.id,
+								ov_mann=ds_m.ov_mann.id,
+								cal_group=ds_m.cal_group
+							)
+						else:
+							lum.Landuse_lum.create(
+								name=lum_name,
+								plnt_com=pcom,
+								mgt=mgt_id,
+								cn2=lum_default_cn2,
+								cons_prac=lum_default_cons_prac,
+								ov_mann=lum_default_ov_mann,
+								cal_group=lum_default_cal_group
+							)
 					else:
 						pcom = None
 						pi = init.Plant_ini.create(

--- a/src/api/fileio/soils.py
+++ b/src/api/fileio/soils.py
@@ -80,20 +80,20 @@ class Soils_sol(BaseFileModel):
 
 					for layer in row.layers:
 						layer_row_cols = [col(" ", padding_override=total_pad),
-										  col(layer.dp),
-										  col(layer.bd),
-										  col(layer.awc),
-										  col(layer.soil_k),
-										  col(layer.carbon),
-										  col(layer.clay),
-										  col(layer.silt),
-										  col(layer.sand),
-										  col(layer.rock),
-										  col(layer.alb),
-										  col(layer.usle_k),
-										  col(layer.ec),
-										  col(layer.caco3),
-										  col(layer.ph)]
+										  col(layer.dp, text_if_null="0.0"),
+										  col(layer.bd, text_if_null="0.0"),
+										  col(layer.awc, text_if_null="0.0"),
+										  col(layer.soil_k, text_if_null="0.0"),
+										  col(layer.carbon, text_if_null="0.0"),
+										  col(layer.clay, text_if_null="0.0"),
+										  col(layer.silt, text_if_null="0.0"),
+										  col(layer.sand, text_if_null="0.0"),
+										  col(layer.rock, text_if_null="0.0"),
+										  col(layer.alb, text_if_null="0.0"),
+										  col(layer.usle_k, text_if_null="0.0"),
+										  col(layer.ec, text_if_null="0.0"),
+										  col(layer.caco3, text_if_null="0.0"),
+										  col(layer.ph, text_if_null="0.0")]
 						self.write_row(file, layer_row_cols)
 						file.write("\n")
 

--- a/src/api/rest/climate.py
+++ b/src/api/rest/climate.py
@@ -209,6 +209,31 @@ def wgnId(id):
 
 	abort(405, 'HTTP Method not allowed.')
 
+@bp.route('/wgn/validate', methods=['GET'])
+def wgnValidate():
+	project_db = request.headers.get(rh.PROJECT_DB)
+	has_db,error = rh.init(project_db)
+	if not has_db: abort(400, error)
+
+	if request.method == 'GET':
+		"""query = (Weather_wgn_cli
+			.select(Weather_wgn_cli.id, fn.COUNT(Weather_wgn_cli_mon.id).alias('months'))
+			.join(Weather_wgn_cli_mon, JOIN.LEFT_OUTER, on=(Weather_wgn_cli.id == Weather_wgn_cli_mon.weather_wgn_cli_id))
+			.where(SQL('months') < 12)
+			.group_by(Weather_wgn_cli.id))"""
+		
+		data = []
+		for wgn in Weather_wgn_cli.select():
+			months = Weather_wgn_cli_mon.select().where(Weather_wgn_cli_mon.weather_wgn_cli_id == wgn.id).count()
+			if months < 12:
+				data.append({ 'id': wgn.id, 'name': wgn.name, 'months': months })
+		
+		rh.close()
+		return {
+			'is_invalid': len(data) > 0,
+			'data': data
+		}
+
 @bp.route('/wgn/db', methods=['GET', 'PUT'])
 def wgnDb():
 	project_db = request.headers.get(rh.PROJECT_DB)

--- a/src/api/rest/hru.py
+++ b/src/api/rest/hru.py
@@ -102,14 +102,22 @@ def properties():
 			m = Hru_data_hru()
 			m.name = args['name']
 			m.description = None if 'description' not in args else args['description']
-			m.topo_id = RestHelpers.get_id_from_name(Topography_hyd, args['topo_name'])
-			m.hydro_id = RestHelpers.get_id_from_name(Hydrology_hyd, args['hyd_name'])
-			m.soil_id = RestHelpers.get_id_from_name(Soils_sol, args['soil_name'])
-			m.lu_mgt_id = RestHelpers.get_id_from_name(Landuse_lum, args['lu_mgt_name'])
-			m.soil_plant_init_id = RestHelpers.get_id_from_name(Soil_plant_ini, args['soil_plant_init_name'])
-			m.surf_stor_id = RestHelpers.get_id_from_name(Wetland_wet, args['surf_stor'])
-			m.snow_id = RestHelpers.get_id_from_name(Snow_sno, args['snow_name'])
-			m.field_id = RestHelpers.get_id_from_name(Field_fld, args['field_name'])
+			if 'topo_name' in args:
+				m.topo_id = RestHelpers.get_id_from_name(Topography_hyd, args['topo_name'])
+			if 'hyd_name' in args:
+				m.hydro_id = RestHelpers.get_id_from_name(Hydrology_hyd, args['hyd_name'])
+			if 'soil_name' in args:
+				m.soil_id = RestHelpers.get_id_from_name(Soils_sol, args['soil_name'])
+			if 'lu_mgt_name' in args:
+				m.lu_mgt_id = RestHelpers.get_id_from_name(Landuse_lum, args['lu_mgt_name'])
+			if 'soil_plant_init_name' in args:
+				m.soil_plant_init_id = RestHelpers.get_id_from_name(Soil_plant_ini, args['soil_plant_init_name'])
+			if 'surf_stor' in args:
+				m.surf_stor_id = RestHelpers.get_id_from_name(Wetland_wet, args['surf_stor'])
+			if 'snow_name' in args:
+				m.snow_id = RestHelpers.get_id_from_name(Snow_sno, args['snow_name'])
+			if 'field_name' in args:
+				m.field_id = RestHelpers.get_id_from_name(Field_fld, args['field_name'])
 
 			result = m.save()
 

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -362,6 +362,11 @@ ipcMain.on('quit-and-install-update', async (event, arg) => {
 	autoUpdater.quitAndInstall();
 });
 
+ipcMain.on('manual-update-check', (event, arg) => {
+	console.log('Checking for updates...');
+	autoUpdater.checkForUpdates();
+});
+
 //IPC functions to connect to renderer
 ipcMain.on('message', (event, message) => {
 	console.log(message);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -90,4 +90,5 @@ contextBridge.exposeInMainWorld('electronApi', {
 	},
 	downloadUpdate: () => ipcRenderer.send('download-update', ''),
 	quitAndInstallUpdate: () => ipcRenderer.send('quit-and-install-update', ''),
+	manualUpdateCheck: () => ipcRenderer.send('manual-update-check', ''),
 })

--- a/src/main/static/appsettings.json
+++ b/src/main/static/appsettings.json
@@ -1,5 +1,5 @@
 {
-	"version": "3.0.5",
+	"version": "3.0.6",
 	"swatplus": "61.0.1",
 	"python": false,
 	"pythonPath": "src/api/.venv/Scripts/python"

--- a/src/renderer/helpers/runProcess.ts
+++ b/src/renderer/helpers/runProcess.ts
@@ -60,6 +60,10 @@ export function useRunProcess() {
 		electron.quitAndInstallUpdate();
 	}
 
+	function manualUpdateCheck() {
+		electron.manualUpdateCheck();
+	}
+
 	return {
 		runApiProc,
 		runSwatProc,
@@ -75,6 +79,7 @@ export function useRunProcess() {
 		appUpdateDownloading,
 		appUpdateDownloaded,
 		downloadUpdate,
-		quitAndInstallUpdate
+		quitAndInstallUpdate,
+		manualUpdateCheck
 	}
 }

--- a/src/renderer/typings/electron.d.ts
+++ b/src/renderer/typings/electron.d.ts
@@ -36,6 +36,7 @@ export default interface ElectronApi {
 	appUpdateDownloaded: (callback:any) => void,
 	downloadUpdate: () => void,
 	quitAndInstallUpdate: () => void,
+	manualUpdateCheck: () => void,
 }
 
 declare global {

--- a/src/renderer/views/Update.vue
+++ b/src/renderer/views/Update.vue
@@ -37,7 +37,8 @@
 
 	let listeners:any = {
 		appUpdateDownloading: undefined,
-		appUpdateDownloaded: undefined
+		appUpdateDownloaded: undefined,
+		appUpdateStatus: undefined,
 	}
 
 	function initRunProcessHandlers() {
@@ -49,6 +50,12 @@
 			data.task.isDownloaded = true;
 			data.task.isDownloading = false;
 		});
+
+		listeners.appUpdateStatus = runProcess.appUpdateStatus((stdData:any) => {
+			console.log(`Update status received: ${stdData}`);
+			let status:any = runProcess.getApiOutput(stdData);
+			appUpdate.setStatus(status.message, status.isAvailable);
+		});
 	}
 
 	function downloadUpdate() {
@@ -59,6 +66,7 @@
 	function removeRunProcessHandlers() {
 		if (listeners.appUpdateDownloading) listeners.appUpdateDownloading();
 		if (listeners.appUpdateDownloaded) listeners.appUpdateDownloaded();
+		if (listeners.appUpdateStatus) listeners.appUpdateStatus();
 	}
 
 	const messageHtml = computed(() => {
@@ -125,6 +133,7 @@
 					</p>
 				</v-card-text>
 				<v-card-actions class="pb-3">
+					<v-btn @click="runProcess.manualUpdateCheck" color="primary" variant="flat"><v-icon class="mr-1">fa-arrows-rotate</v-icon> Check Again</v-btn>	
 					<v-btn to="/" color="secondary" variant="text">Return to Project</v-btn>
 				</v-card-actions>
 			</v-card>

--- a/src/renderer/views/edit/decision_table/DecisionsGrid.vue
+++ b/src/renderer/views/edit/decision_table/DecisionsGrid.vue
@@ -38,8 +38,8 @@
 		<v-alert v-if="decisionsTable==='flo_con.dtl'" type="warning" icon="$warning" variant="tonal" border="start" class="mb-4">
 			We recommend not using flow condition tables at this time unless you are an advanced user who has already been in touch with the SWAT+ model development team to discuss your needs.
 		</v-alert>
-		<v-alert v-if="decisionsTable==='scen_lu.dtl'" type="info" icon="$info" variant="tonal" border="start" class="mb-4">
-			Any land use scenarios added to your project tables below will be applied to your model. <br />Browse the datasets library tab and copy a scenario to your project as needed.
+		<v-alert v-if="decisionsTable==='scen_lu.dtl'" type="warning" icon="$warning" variant="tonal" border="start" class="mb-4">
+			Support for scenario land use decision tables is planned for a <b>SWAT+ Editor 3.1 release</b>. In the interim, please add these tables and a scen_dtl.upd file outside of the interface. Contact the model development team for assistance.
 		</v-alert>
 		
 		<v-card>

--- a/src/renderer/views/edit/decision_table/FloCon.vue
+++ b/src/renderer/views/edit/decision_table/FloCon.vue
@@ -6,7 +6,7 @@
 
 <template>
 	<project-container>
-		<div v-if="$route.name == 'DecisionsFloCon'">
+		<div v-if="route.name == 'DecisionsFloCon'">
 			<decisions-grid decisions-table="flo_con.dtl" description="Flow Conditions"></decisions-grid>
 		</div>
 		<router-view></router-view>

--- a/src/renderer/views/edit/decision_table/Lum.vue
+++ b/src/renderer/views/edit/decision_table/Lum.vue
@@ -6,7 +6,7 @@
 
 <template>
 	<project-container>
-		<div v-if="$route.name == 'DecisionsLum'">
+		<div v-if="route.name == 'DecisionsLum'">
 			<decisions-grid decisions-table="lum.dtl" description="Land Use Management"></decisions-grid>
 		</div>
 		<router-view></router-view>

--- a/src/renderer/views/edit/decision_table/ResRel.vue
+++ b/src/renderer/views/edit/decision_table/ResRel.vue
@@ -6,7 +6,7 @@
 
 <template>
 	<project-container>
-		<div v-if="$route.name == 'DecisionsResRel'">
+		<div v-if="route.name == 'DecisionsResRel'">
 			<decisions-grid decisions-table="res_rel.dtl" description="Reservoir Release"></decisions-grid>
 		</div>
 		<router-view></router-view>

--- a/src/renderer/views/edit/decision_table/ScenLu.vue
+++ b/src/renderer/views/edit/decision_table/ScenLu.vue
@@ -6,7 +6,7 @@
 
 <template>
 	<project-container>
-		<div v-if="$route.name == 'DecisionsScenLu'">
+		<div v-if="route.name == 'DecisionsScenLu'">
 			<decisions-grid decisions-table="scen_lu.dtl" description="Scenario Land Use"></decisions-grid>
 		</div>
 		<router-view></router-view>


### PR DESCRIPTION
* Fix SWAT+ Check to allow null land use management pointer in HRUs.
* Fix importing from GIS to allow default land use management properties when user-added non-standard plant codes to swatplus_datasets.sqlite.
* Fix printing 0 value instead of null for missing soils values.
* Add check for empty weather generator data and issue warning both on WGN page and the run model page.
* Add note about future support for scenario land use update decision tables, planned for editor v3.1.
* Add manual check for updates button.