### PR TITLE
add netcdf climate preparation to api

### DIFF
--- a/src/api/actions/import_weather.py
+++ b/src/api/actions/import_weather.py
@@ -2,7 +2,7 @@ from helpers.executable_api import ExecutableApi, Unbuffered
 from database.project import base as project_base
 from database.project.setup import SetupProjectDatabase
 from database.project.config import Project_config
-from database.project.climate import Weather_file, Weather_sta_cli, Weather_wgn_cli, Weather_wgn_cli_mon, Atmo_cli, Atmo_cli_sta, Atmo_cli_sta_value
+from database.project.climate import Weather_file, Weather_sta_cli, Weather_sta_cli_scale, Weather_wgn_cli, Weather_wgn_cli_mon, Atmo_cli, Atmo_cli_sta, Atmo_cli_sta_value
 from database.project.connect import Aquifer_con, Channel_con, Rout_unit_con, Reservoir_con, Recall_con, Hru_con, Exco_con, Chandeg_con, Hru_lte_con
 from database.project.simulation import Time_sim
 from database import lib as db_lib
@@ -384,6 +384,272 @@ class WeatherImport(ExecutableApi):
 				start_date = max(starts)
 				end_date = min(ends)
 		return start_date, end_date
+
+
+class NetCDFWeatherImport(ExecutableApi):
+	"""
+	Import weather stations from a CSV file containing station coordinates and variable availability.
+	This is used when weather data comes from NetCDF files where station locations are defined in a CSV.
+	
+	CSV format: lat,lon,elev,pcp,tmin,tmax,slr,hmd,wnd,pet
+	- elev: can be null (treated as 0)
+	- variable columns: scaling factor as float, null/-99 = no data (stored as None)
+	"""
+	def __init__(self, project_db_file, delete_existing, create_stations, stations_csv_file, nc_data_file=None):
+		self.__abort = False
+		SetupProjectDatabase.init(project_db_file)
+		self.project_db_file = project_db_file
+		self.project_db = project_base.db
+		self.create_stations = create_stations
+		self.stations_csv_file = stations_csv_file
+		self.nc_data_file = nc_data_file
+		self.coords_to_stations = {}
+		# Store scale factors per station name for later insertion
+		self.station_scale_factors = {}
+
+		# Ensure the scale table exists (for databases created before this feature)
+		project_base.db.create_tables([Weather_sta_cli_scale], safe=True)
+
+		# Ensure netcdf_data_file column exists in project_config (for databases created before this feature)
+		self._ensure_netcdf_data_file_column()
+		
+		# Ensure out_path classification exists in file_cio_classification (for databases created before this feature)
+		self._ensure_out_path_classification()
+
+		if delete_existing:
+			self.delete_existing()
+
+	def _ensure_netcdf_data_file_column(self):
+		"""Add the netcdf_data_file column to project_config if it doesn't exist."""
+		try:
+			cursor = project_base.db.execute_sql("PRAGMA table_info(project_config)")
+			columns = [row[1] for row in cursor.fetchall()]
+			if 'netcdf_data_file' not in columns:
+				project_base.db.execute_sql("ALTER TABLE project_config ADD COLUMN netcdf_data_file VARCHAR(255) NULL")
+		except Exception as e:
+			print("Warning: Could not add netcdf_data_file column: {}".format(e))
+
+	def _ensure_out_path_classification(self):
+		"""Add the out_path classification to file_cio_classification if it doesn't exist."""
+		try:
+			cursor = project_base.db.execute_sql("SELECT id FROM file_cio_classification WHERE name = 'out_path'")
+			if cursor.fetchone() is None:
+				project_base.db.execute_sql("INSERT INTO file_cio_classification (id, name) VALUES (31, 'out_path')")
+		except Exception as e:
+			print("Warning: Could not add out_path classification: {}".format(e))
+
+	def import_data(self):
+		try:
+			if not os.path.exists(self.stations_csv_file):
+				sys.exit('Stations CSV file {file} does not exist.'.format(file=self.stations_csv_file))
+
+			self.add_weather_files_from_csv()
+
+			if self.create_stations:
+				self.create_weather_stations(20, 45)
+				self.add_scale_factors(85)
+				self.match_stations(90)
+			else:
+				self.match_files_to_stations(20, 45)
+				self.add_scale_factors(85)
+			
+			# Update project_config to indicate netcdf weather format
+			self.update_project_config()
+		except Exception as e:
+			sys.exit('Error importing NetCDF stations: {}'.format(str(e)))
+
+	def delete_existing(self):
+		Weather_sta_cli_scale.delete().execute()
+		Weather_file.delete().execute()
+		Weather_sta_cli.delete().execute()
+
+	def update_project_config(self):
+		"""Update project_config to set weather_data_format to 'netcdf' and store nc data file path."""
+		self.emit_progress(95, "Updating project configuration...")
+		try:
+			config = Project_config.get()
+			config.weather_data_format = 'netcdf'
+			if self.nc_data_file:
+				config.netcdf_data_file = self.nc_data_file
+			config.save()
+		except Project_config.DoesNotExist:
+			pass
+
+	def parse_scale_value(self, val):
+		"""Parse a scale value from CSV. Returns None for null/-99, float otherwise."""
+		if val is None:
+			return None
+		val_str = val.strip().lower()
+		if val_str in ('null', '-99', ''):
+			return None
+		try:
+			return float(val)
+		except ValueError:
+			return None
+
+	def add_weather_files_from_csv(self):
+		"""Read the stations CSV file and add weather file entries for each station/variable combination."""
+		if self.__abort: return
+		
+		self.emit_progress(0, "Reading stations CSV file...")
+		
+		weather_files = []
+		
+		# Map CSV column names to weather types for weather_file table
+		# CSV has: pcp, tmin, tmax (combined as tmp), slr, hmd, wnd, pet
+		var_to_type = {
+			'pcp': 'pcp',
+			'tmin': 'tmp',  # tmin and tmax are combined as tmp
+			'tmax': 'tmp',
+			'slr': 'slr',
+			'hmd': 'hmd',
+			'wnd': 'wnd',
+			'pet': 'pet'
+		}
+		
+		# Scale factor columns in CSV (stored separately in weather_sta_cli_scale)
+		scale_cols = ['pcp', 'tmin', 'tmax', 'slr', 'hmd', 'wnd', 'pet']
+		
+		try:
+			with open(self.stations_csv_file, 'r') as csvfile:
+				reader = csv.DictReader(csvfile)
+				
+				row_count = 0
+				for row in reader:
+					if self.__abort: return
+					
+					lat = float(row['lat'])
+					lon = float(row['lon'])
+					
+					# Generate a station filename based on coordinates
+					station_name = weather_sta_name(lat, lon)
+					
+					# Store scale factors for this station
+					scale_factors = {}
+					for col in scale_cols:
+						if col in row:
+							scale_factors[col] = self.parse_scale_value(row[col])
+						else:
+							scale_factors[col] = None
+					self.station_scale_factors[station_name] = scale_factors
+					
+					# Track which weather types we've added for this station
+					# (to avoid duplicates for tmp from tmin/tmax)
+					added_types = set()
+					
+					for var_col, weather_type in var_to_type.items():
+						if var_col in row:
+							scale_val = self.parse_scale_value(row[var_col])
+							# Check if this variable has data (scale value is not None)
+							has_data = scale_val is not None
+							
+							if has_data and weather_type not in added_types:
+								filename = "{name}.{ext}".format(name=station_name, ext=weather_type)
+								
+								try:
+									existing = Weather_file.get((Weather_file.filename == filename) & (Weather_file.type == weather_type))
+								except Weather_file.DoesNotExist:
+									file_entry = {
+										"filename": filename,
+										"type": weather_type,
+										"lat": lat,
+										"lon": lon
+									}
+									weather_files.append(file_entry)
+									added_types.add(weather_type)
+					
+					row_count += 1
+					if row_count % 100 == 0:
+						self.emit_progress(min(15, row_count // 50), "Processing station {num}...".format(num=row_count))
+				
+				self.emit_progress(15, "Inserting {count} weather file entries...".format(count=len(weather_files)))
+				db_lib.bulk_insert(project_base.db, Weather_file, weather_files)
+				
+		except UnicodeDecodeError:
+			sys.exit('Non-unicode character detected in {}. Please check your CSV file encoding.'.format(self.stations_csv_file))
+
+	def create_weather_stations(self, start_prog, total_prog):
+		"""Create weather stations from unique lat/lon combinations in weather_file table."""
+		if self.__abort: return
+
+		stations = []
+		cursor = project_base.db.execute_sql("select lat, lon from weather_file group by lat, lon")
+		data = cursor.fetchall()
+		records = len(data)
+		i = 1
+		for row in data:
+			if self.__abort: return
+
+			lat = row[0]
+			lon = row[1]
+			name = weather_sta_name(lat, lon)
+
+			prog = round(i * total_prog / records) + start_prog
+			self.emit_progress(prog, "Creating weather station {name}...".format(name=name))
+
+			try:
+				existing = Weather_sta_cli.get(Weather_sta_cli.name == name)
+			except Weather_sta_cli.DoesNotExist:
+				station = {
+					"name": name,
+					"atmo_dep": None,
+					"lat": lat,
+					"lon": lon,
+				}
+				stations.append(station)
+			i += 1
+
+		db_lib.bulk_insert(project_base.db, Weather_sta_cli, stations)
+		self.match_files_to_stations(start_prog + total_prog, 20)
+
+	def match_files_to_stations(self, start_prog, total_prog):
+		"""Match weather files to weather stations based on lat/lon proximity."""
+		self.emit_progress(start_prog, "Matching files to weather station...")
+		update_closest_lat_lon("weather_sta_cli", "hmd", "weather_file", "filename", "hmd")
+		update_closest_lat_lon("weather_sta_cli", "pcp", "weather_file", "filename", "pcp")
+		update_closest_lat_lon("weather_sta_cli", "slr", "weather_file", "filename", "slr")
+		update_closest_lat_lon("weather_sta_cli", "tmp", "weather_file", "filename", "tmp")
+		update_closest_lat_lon("weather_sta_cli", "wnd", "weather_file", "filename", "wnd")
+		update_closest_lat_lon("weather_sta_cli", "pet", "weather_file", "filename", "pet")
+
+	def match_stations(self, start_prog):
+		"""Assign weather stations to spatial connection tables."""
+		self.emit_progress(start_prog, "Adding weather stations to spatial connection tables...")
+		wst_col = "wst_id"
+		wst_table = "weather_sta_cli"
+		update_closest_lat_lon("aquifer_con", wst_col, wst_table)
+		update_closest_lat_lon("channel_con", wst_col, wst_table)
+		update_closest_lat_lon("chandeg_con", wst_col, wst_table)
+		update_closest_lat_lon("rout_unit_con", wst_col, wst_table)
+		update_closest_lat_lon("reservoir_con", wst_col, wst_table)
+		update_closest_lat_lon("recall_con", wst_col, wst_table)
+		update_closest_lat_lon("exco_con", wst_col, wst_table)
+		update_closest_lat_lon("hru_con", wst_col, wst_table)
+		update_closest_lat_lon("hru_lte_con", wst_col, wst_table)
+		update_closest_lat_lon("weather_sta_cli", "wgn_id", "weather_wgn_cli")
+
+	def add_scale_factors(self, start_prog):
+		"""Add scale factors for each weather station from the stored CSV values."""
+		self.emit_progress(start_prog, "Adding scale factors for weather stations...")
+		
+		scale_entries = []
+		for station in Weather_sta_cli.select():
+			if station.name in self.station_scale_factors:
+				factors = self.station_scale_factors[station.name]
+				scale_entry = {
+					"weather_sta_cli": station.id,
+					"pcp": factors.get('pcp'),
+					"tmin": factors.get('tmin'),
+					"tmax": factors.get('tmax'),
+					"slr": factors.get('slr'),
+					"hmd": factors.get('hmd'),
+					"wnd": factors.get('wnd'),
+					"pet": factors.get('pet')
+				}
+				scale_entries.append(scale_entry)
+		
+		if scale_entries:
+			db_lib.bulk_insert(project_base.db, Weather_sta_cli_scale, scale_entries)
 
 
 class Swat2012WeatherImport(ExecutableApi):

--- a/src/api/database/datasets/setup.py
+++ b/src/api/database/datasets/setup.py
@@ -228,7 +228,8 @@ class SetupDatasetsDatabase():
 			{'id': 27, 'name': 'tmp_path'},
 			{'id': 28, 'name': 'slr_path'},
 			{'id': 29, 'name': 'hmd_path'},
-			{'id': 30, 'name': 'wnd_path'}
+			{'id': 30, 'name': 'wnd_path'},
+			{'id': 31, 'name': 'out_path'}
 		]
 		
 		file_cio = [

--- a/src/api/database/project/climate.py
+++ b/src/api/database/project/climate.py
@@ -48,6 +48,18 @@ class Weather_sta_cli(BaseModel):
 		return cls.select().where((cls.pcp != 'sim') | (cls.tmp != 'sim') | (cls.slr != 'sim') | (cls.hmd != 'sim') | (cls.wnd != 'sim') | (cls.pet != 'sim')).count()
 
 
+class Weather_sta_cli_scale(BaseModel):
+	"""Scaling factors for weather station variables, used with NetCDF weather data."""
+	weather_sta_cli = ForeignKeyField(Weather_sta_cli, related_name='scale_factors', on_delete='CASCADE')
+	pcp = DoubleField(null=True)
+	tmin = DoubleField(null=True)
+	tmax = DoubleField(null=True)
+	slr = DoubleField(null=True)
+	hmd = DoubleField(null=True)
+	wnd = DoubleField(null=True)
+	pet = DoubleField(null=True)
+
+
 class Weather_file(BaseModel):
 	filename = CharField()
 	type = CharField()

--- a/src/api/database/project/config.py
+++ b/src/api/database/project/config.py
@@ -24,6 +24,7 @@ class Project_config(base.BaseModel):
 	wgn_table_name = CharField(null=True)
 	weather_data_dir = CharField(null=True)
 	weather_data_format = CharField(null=True)
+	netcdf_data_file = CharField(null=True)
 	input_files_dir = CharField(null=True)
 	input_files_last_written = DateTimeField(null=True)
 	swat_last_run = DateTimeField(null=True)

--- a/src/api/database/project/setup.py
+++ b/src/api/database/project/setup.py
@@ -49,7 +49,7 @@ class SetupProjectDatabase():
 		base.db.create_tables([config.Project_config, config.File_cio_classification, config.File_cio])
 		base.db.create_tables([basin.Codes_bsn, basin.Parameters_bsn])
 		base.db.create_tables([simulation.Time_sim, simulation.Print_prt, simulation.Print_prt_aa_int, simulation.Print_prt_object, simulation.Object_prt, simulation.Object_cnt, simulation.Constituents_cs])
-		base.db.create_tables([climate.Weather_wgn_cli, climate.Weather_wgn_cli_mon, climate.Weather_sta_cli, climate.Weather_file, climate.Wind_dir_cli, climate.Atmo_cli, climate.Atmo_cli_sta, climate.Atmo_cli_sta_value])
+		base.db.create_tables([climate.Weather_wgn_cli, climate.Weather_wgn_cli_mon, climate.Weather_sta_cli, climate.Weather_sta_cli_scale, climate.Weather_file, climate.Wind_dir_cli, climate.Atmo_cli, climate.Atmo_cli_sta, climate.Atmo_cli_sta_value])
 		base.db.create_tables([link.Chan_aqu_lin, link.Chan_aqu_lin_ob, link.Chan_surf_lin, link.Chan_surf_lin_ob])
 		base.db.create_tables([channel.Initial_cha, channel.Hydrology_cha, channel.Sediment_cha, channel.Nutrients_cha, channel.Channel_cha, channel.Hyd_sed_lte_cha, channel.Channel_lte_cha])
 		base.db.create_tables([reservoir.Initial_res, reservoir.Hydrology_res, reservoir.Sediment_res, reservoir.Nutrients_res, reservoir.Weir_res, reservoir.Reservoir_res, reservoir.Hydrology_wet, reservoir.Wetland_wet])

--- a/src/api/fileio/climate.py
+++ b/src/api/fileio/climate.py
@@ -1,7 +1,99 @@
 from .base import BaseFileModel, FileColumn as col
 from peewee import *
 import database.project.climate as db
+import database.project.config as config_db
 from helpers import utils
+import os
+
+
+class Netcdf_ncw(BaseFileModel):
+	"""Write the netcdf.ncw file for NetCDF weather data format."""
+	def __init__(self, file_name, version=None, swat_version=None):
+		self.file_name = file_name
+		self.version = version
+		self.swat_version = swat_version
+
+	def read(self):
+		raise NotImplementedError('Reading not implemented yet.')
+
+	def write(self):
+		table = db.Weather_sta_cli
+		scale_table = db.Weather_sta_cli_scale
+		
+		# Get the netcdf data file name from project config
+		project_config = config_db.Project_config.get_or_none()
+		nc_filename = None
+		if project_config and project_config.netcdf_data_file:
+			nc_filename = os.path.basename(project_config.netcdf_data_file)
+		
+		# Query stations with their WGN and scale factors
+		query = (table.select(table.name,
+							  db.Weather_wgn_cli.name.alias("wgn"),
+							  table.lat,
+							  table.lon)
+					  .join(db.Weather_wgn_cli, JOIN.LEFT_OUTER)
+					  .order_by(table.name))
+		
+		# Build a dict of scale factors by station id
+		scale_factors = {}
+		for sf in scale_table.select():
+			scale_factors[sf.weather_sta_cli_id] = sf
+		
+		with open(self.file_name, 'w') as file:
+			self.write_meta_line(file)
+			
+			# Write header row
+			headers = ['name', 'wgn', 'latitude', 'longitude', 'elevation', 
+					   'pcp', 'tmin', 'tmax', 'slr', 'hmd', 'wnd', 'pet']
+			for h in headers:
+				if h == 'name':
+					utils.write_string(file, h, default_pad=20, direction="left")
+				elif h == 'wgn':
+					utils.write_string(file, h, default_pad=12, direction="left")
+				else:
+					utils.write_string(file, h, default_pad=12, direction="right")
+			file.write("\n")
+			
+			# Write data rows
+			for station in table.select().join(db.Weather_wgn_cli, JOIN.LEFT_OUTER).order_by(table.name):
+				wgn_name = station.wgn.name if station.wgn else "null"
+				
+				# Get scale factors for this station
+				sf = scale_factors.get(station.id)
+				
+				# Get elevation from WGN if available
+				elev = station.wgn.elev if station.wgn else 0.0
+				
+				# Write station name
+				utils.write_string(file, station.name, default_pad=20, direction="left")
+				# Write WGN name
+				utils.write_string(file, wgn_name, default_pad=12, direction="left")
+				# Write lat/lon/elev
+				utils.write_num(file, station.lat, default_pad=12, decimals=3)
+				utils.write_num(file, station.lon, default_pad=12, decimals=3)
+				utils.write_num(file, elev, default_pad=12, decimals=3)
+				
+				# Write scale factors (or null if not available)
+				if sf:
+					self._write_scale_value(file, sf.pcp)
+					self._write_scale_value(file, sf.tmin)
+					self._write_scale_value(file, sf.tmax)
+					self._write_scale_value(file, sf.slr)
+					self._write_scale_value(file, sf.hmd)
+					self._write_scale_value(file, sf.wnd)
+					self._write_scale_value(file, sf.pet)
+				else:
+					for _ in range(7):
+						utils.write_string(file, "null", default_pad=12, direction="right")
+				
+				file.write("\n")
+
+	def _write_scale_value(self, file, value):
+		"""Write a scale factor value, using 'null' for None."""
+		if value is None:
+			utils.write_string(file, "null", default_pad=12, direction="right")
+		else:
+			utils.write_num(file, value, default_pad=12, decimals=1)
 
 
 class Weather_sta_cli(BaseFileModel):

--- a/src/api/rest/setup.py
+++ b/src/api/rest/setup.py
@@ -180,7 +180,7 @@ def getFileCio():
 	if c is not None:
 		is_lte = c.is_lte
 
-	ignore = ['pcp_path', 'tmp_path', 'slr_path', 'hmd_path', 'wnd_path']
+	ignore = ['pcp_path', 'tmp_path', 'slr_path', 'hmd_path', 'wnd_path', 'out_path']
 	classes = config.File_cio_classification.select().where(config.File_cio_classification.name.not_in(ignore)).order_by(config.File_cio_classification.id)
 	files = config.File_cio.select().order_by(config.File_cio.order_in_class)
 	query = prefetch(classes, files)

--- a/src/api/swatplus_api.py
+++ b/src/api/swatplus_api.py
@@ -1,7 +1,7 @@
 from helpers.executable_api import Unbuffered
 from actions.setup_project import SetupProject
 from actions.import_gis import GisImport
-from actions.import_weather import WeatherImport, Swat2012WeatherImport, WgnImport, AtmoImport
+from actions.import_weather import WeatherImport, Swat2012WeatherImport, WgnImport, AtmoImport, NetCDFWeatherImport
 from actions.read_output import ReadOutput
 from actions.write_files import WriteFiles
 from actions.create_databases import CreateDatasetsDb, CreateOutputDb, CreateProjectDb
@@ -31,6 +31,8 @@ if __name__ == '__main__':
 	parser.add_argument("--import_method", type=str, help="import method for wgn (database, two_file, one_file)", nargs="?")
 	parser.add_argument("--file1", type=str, help="full path of file", nargs="?")
 	parser.add_argument("--file2", type=str, help="full path of file", nargs="?")
+	parser.add_argument("--nc_stations_list", type=str, help="full path of CSV file with NetCDF station coordinates and variable availability", nargs="?")
+	parser.add_argument("--nc_file", type=str, help="full path of NetCDF data file (.nc4) to copy to TxtInOut", nargs="?")
 
 	# read output
 	parser.add_argument("--output_files_dir", type=str, help="full path of output files directory", nargs="?")
@@ -108,6 +110,13 @@ if __name__ == '__main__':
 			api.import_data()
 		elif args.import_type == "observed2012":
 			api = Swat2012WeatherImport(args.project_db_file, del_ex, cre_sta, args.source_dir)
+			api.import_data()
+		elif args.import_type == "netcdf":
+			# Use nc_stations_list or file1 for the CSV file path
+			stations_csv = args.nc_stations_list if args.nc_stations_list else args.file1
+			if not stations_csv:
+				sys.exit("Error: --nc_stations_list or --file1 is required for netcdf import type")
+			api = NetCDFWeatherImport(args.project_db_file, del_ex, cre_sta, stations_csv, args.nc_file)
 			api.import_data()
 		elif args.import_type == "wgn":
 			api = WgnImport(args.project_db_file, del_ex, cre_sta, args.import_method, args.file1, args.file2)


### PR DESCRIPTION
This pull request introduces support for NetCDF-based weather data import and processing within the project. It adds a new workflow for handling weather stations and scaling factors from NetCDF sources, modifies the configuration and file writing logic to accommodate this new format, and ensures relevant database schema changes. The changes are grouped into three main themes: NetCDF weather data import, database/model updates, and file I/O/configuration handling.

**NetCDF Weather Data Import:**

- Added a new `NetCDFWeatherImport` class to `import_weather.py` to handle importing weather station metadata and scale factors from a CSV (for NetCDF-based weather workflows), including new logic for creating, matching, and scaling weather stations, and updating the project configuration for NetCDF support.
- Modified weather file copying and writing logic in `write_files.py` to skip standard weather files when NetCDF is used, copy the NetCDF data file if specified, and generate a `netcdf.ncw` file instead of the usual `weather-sta.cli`.

**Database and Model Updates:**

- Introduced a new model `Weather_sta_cli_scale` to store per-station weather variable scaling factors, and ensured its creation in the database setup routines.
- Added a `netcdf_data_file` field to the `Project_config` model to store the path to the NetCDF weather data file.
- Updated file CIO classification setup to include a new `out_path` classification for NetCDF support.
- Updated import statements to include the new `Weather_sta_cli_scale` model where needed.

**File I/O and Configuration Handling:**

- Added a new `Netcdf_ncw` file writer in `climate.py` to output the required metadata and scaling factors for NetCDF-based weather stations.
- Enhanced the configuration file writer in `config.py` to handle NetCDF-specific logic, such as writing the NetCDF filename for weather paths and replacing the climate file entry with `netcdf.ncw` when NetCDF is used.

These changes enable seamless import, configuration, and file output for projects using NetCDF weather data, while maintaining backward compatibility with existing workflows.


## Important
refer to 'https://github.com/celray/swat2netcdf' for auto conversion of text based climate data to NetCDF format for SWAT+ and 'https://github.com/celray/nc2stations' for a tool that creates the CSV metadata file that works with the SPE API.