### PR TITLE
Revision 4.0.1

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 ## Version 3 ##
 
+### Revision 4.0.1 ###
+
+* Bug fix related to codes_bsn/i_fpwet column name change giving an error on new project setups using an old swatplus_datasets.sqlite version.
+* **IMPORTANT:** Time-series recall (point source/inlet) data is still not supported in this release. Please keep using version 3.2.x and do not upgrade yet if you need recall.
+
 ### Revision 4.0.0 ###
 **IMPORTANT:** This new version of the editor is only compatible with SWAT+ rev. 62 and later. Due to structural model changes, rev. 61 and earlier are NOT supported. Project updates are available after software update.
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "swatplus-editor",
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"description": "SWAT+ Editor",
 	"author": "Jaclyn Tech <jaclynt@tamu.edu>",
 	"private": true,

--- a/release/build/release-notes.md
+++ b/release/build/release-notes.md
@@ -1,3 +1,8 @@
+### SWAT+ Editor 4.0.1 ###
+
+* Bug fix related to codes_bsn/i_fpwet column name change giving an error on new project setups using an old swatplus_datasets.sqlite version.
+* **IMPORTANT:** Time-series recall (point source/inlet) data is still not supported in this release. Please keep using version 3.2.x and do not upgrade yet if you need recall.
+
 ### SWAT+ Editor 4.0.0 ###
 **IMPORTANT:** This new version of the editor is only compatible with SWAT+ rev. 62 and later. Due to structural model changes, rev. 61 and earlier are NOT supported. Project updates are available after software update.
 

--- a/release/combined-installer-inno.iss
+++ b/release/combined-installer-inno.iss
@@ -2,7 +2,7 @@
 
 #define SWATPlusVersion "4.0"
 #define SWATPlusPatchVersion "0"
-#define SWATPlusToolsPatchVersion "0"
+#define SWATPlusToolsPatchVersion "1"
 #define QSWATPlusVersion "4.0"
 #define QSWATPlusPatchVersion "1"
 #define ToolboxVersion "4"

--- a/src/api/actions/setup_project.py
+++ b/src/api/actions/setup_project.py
@@ -61,13 +61,14 @@ def automatic_updates(project_db):
 			if lib.exists_table(conn, 'plants_plt'):
 				lib.delete_table(project_db, 'plants_plt')
 	
-	if lib.exists_table(conn, 'codes_bsn'):
+	# Disable below due to column name change in 4.0.
+	"""if lib.exists_table(conn, 'codes_bsn'):
 		m = Project_config.get_or_none()
 		if m is not None and (m.editor_version == '3.0.0' or m.editor_version == '3.0.1'):
 			cb = basin.Codes_bsn.get_or_none()
 			if cb is not None and cb.i_fpwet == 2:
 				basin.Codes_bsn.update({basin.Codes_bsn.i_fpwet: 1}).execute()
-				Project_config.update({Project_config.editor_version: '3.0.2'}).execute()
+				Project_config.update({Project_config.editor_version: '3.0.2'}).execute()"""
 
 	if lib.exists_table(conn, 'file_cio'):
 		config_cols = lib.get_column_names(conn, 'file_cio')
@@ -155,17 +156,17 @@ class SetupProject(ExecutableApi):
 				if int(ver) < 40:
 					raise Exception("QSWAT+ version 4.0 or higher is required for new projects in SWAT+ Editor 4. Please either update your QSWAT+ or use version 3.x of the editor instead.")
 
+			# Run dataset updates if needed
+			SetupDatasetsDatabase.init(datasets_db)
+			version = Version.get_or_none()
+			if version is not None and update_datasets.available_to_update(version.value):
+				update_datasets.UpdateDatasets(editor_version, datasets_db)
+
 			self.emit_progress(10, 'Creating database tables...')
 			SetupProjectDatabase.create_tables()
 			self.emit_progress(50, 'Copying data from SWAT+ datasets database...')
 			description = project_description if project_description is not None and project_description != 'null' else project_name
 			SetupProjectDatabase.initialize_data(description, is_lte, overwrite_plants=OVERWRITE_PLANTS)
-
-			# Run updates if needed
-			SetupDatasetsDatabase.init(datasets_db)
-			version = Version.get_or_none()
-			if version is not None and update_datasets.available_to_update(version.value):
-				update_datasets.UpdateDatasets(editor_version, datasets_db)
 
 			existing_config = Project_config.get_or_none()
 			if existing_config is not None and existing_config.editor_version is not None and update_project.available_to_update(existing_config.editor_version):

--- a/src/api/actions/update_datasets.py
+++ b/src/api/actions/update_datasets.py
@@ -116,24 +116,24 @@ class UpdateDatasets(ExecutableApi):
 		if not self.name_exists(dataset_print_prt_object, 'gwflow_obs'): dataset_print_prt_object.create(name='gwflow_obs', daily=0, monthly=0, yearly=0, avann=0, print_prt_id=1)
 		if not self.name_exists(dataset_print_prt_object, 'gwflow_pump'): dataset_print_prt_object.create(name='gwflow_pump', daily=0, monthly=0, yearly=0, avann=0, print_prt_id=1)
 
-		#try:
-		db = SqliteDatabase(datasets_db, timeout=10)
+		try:
+			db = SqliteDatabase(datasets_db, timeout=10)
 
-		# Drop the broken index before migrations
-		db.execute_sql('DROP INDEX IF EXISTS management_sch_auto_plant1_id')
-		db.execute_sql('DROP INDEX IF EXISTS management_sch_auto_plant2_id')
+			# Drop the broken index before migrations
+			db.execute_sql('DROP INDEX IF EXISTS management_sch_auto_plant1_id')
+			db.execute_sql('DROP INDEX IF EXISTS management_sch_auto_plant2_id')
 
-		migrator = SqliteMigrator(db)
-		# Run migrations separately
-		with db.atomic():
-			migrate(migrator.add_column('codes_bsn', 'idc_till', IntegerField(default=3)))
+			migrator = SqliteMigrator(db)
+			# Run migrations separately
+			with db.atomic():
+				migrate(migrator.add_column('codes_bsn', 'idc_till', IntegerField(default=3)))
 
-		with db.atomic():
-			migrate(migrator.rename_column('codes_bsn', 'i_fpwet', 'qual2e', legacy=False))
+			with db.atomic():
+				migrate(migrator.rename_column('codes_bsn', 'i_fpwet', 'qual2e', legacy=False))
 
-		db.close()
-		#except Exception:
-		#	pass
+			db.close()
+		except Exception:
+			sys.exit("Error trying to update swatplus_datasets.sqlite codes_bsn table for 4.0. Please download the 4.0 version online and replace your current datasets database with it. Then re-run the update process.")
 	
 	def updates_for_3_2_0(self, datasets_db):
 		if not self.name_exists(dataset_file_cio_classification, 'out_path'): dataset_file_cio_classification.insert(name='out_path').execute()
@@ -159,7 +159,7 @@ class UpdateDatasets(ExecutableApi):
 		dataset_file_cio.update({dataset_file_cio.default_file_name: 'gwflow.con'}).where(dataset_file_cio.default_file_name == 'modflow.con').execute()
 		dataset_file_cio.update({dataset_file_cio.default_file_name: 'pesticide.pst'}).where(dataset_file_cio.default_file_name == 'pesticide.pes').execute()
 		datasets_hru_parm_db.Pesticide_pst.update({datasets_hru_parm_db.Pesticide_pst.aq_hlife: 142.85, datasets_hru_parm_db.Pesticide_pst.ben_hlife: 20}).execute()
-		datasets_basin.Codes_bsn.update({datasets_basin.Codes_bsn.i_fpwet: 1}).execute()
+		#datasets_basin.Codes_bsn.update({datasets_basin.Codes_bsn.i_fpwet: 1}).execute()
 
 		self.plant_value_updates_for_3_0_0(datasets_hru_parm_db.Plants_plt)
 		self.cal_parms_value_updates_for_3_0_0(datasets_change.Cal_parms_cal)

--- a/src/api/actions/update_project.py
+++ b/src/api/actions/update_project.py
@@ -68,10 +68,11 @@ class UpdateProject(ExecutableApi):
 			rel_datasets_db = os.path.relpath(datasets_db, base_path)
 			m.reference_db = rel_datasets_db
 
+		# Disabled in 4.0 because datasets update is separated and should not need this check here.
 		# Ensure correct version of datasets db
-		ver_check = SetupDatasetsDatabase.check_version(datasets_db, new_version, True)
+		"""ver_check = SetupDatasetsDatabase.check_version(datasets_db, new_version, True)
 		if ver_check is not None:
-			sys.exit(ver_check)
+			sys.exit(ver_check)"""
 		
 		# Find matching upgrade path
 		version = m.editor_version
@@ -150,7 +151,7 @@ class UpdateProject(ExecutableApi):
 
 			db.close()
 		except:
-			pass # Ignore errors from migrations
+			sys.exit("Error trying to update your project sqlite codes_bsn table for 4.0. Please contact the user group and post a link for the team to download your project.")
 		
 			
 	def migrate_gwflow_4_0_0(self, project_db):
@@ -483,7 +484,7 @@ class UpdateProject(ExecutableApi):
 
 		hru_parm_db.Pesticide_pst.update({hru_parm_db.Pesticide_pst.aq_hlife: 142.85, hru_parm_db.Pesticide_pst.ben_hlife: 20}).execute()
 
-		basin.Codes_bsn.update({basin.Codes_bsn.i_fpwet: 1}).execute()
+		#basin.Codes_bsn.update({basin.Codes_bsn.i_fpwet: 1}).execute()
 
 		self.plant_value_updates_for_3_0_0(hru_parm_db.Plants_plt)
 

--- a/src/main/static/appsettings.json
+++ b/src/main/static/appsettings.json
@@ -1,5 +1,5 @@
 {
-	"version": "4.0.0",
+	"version": "4.0.1",
 	"swatplus": "62",
 	"python": false,
 	"pythonPath": "src/api/.venv/Scripts/python"


### PR DESCRIPTION
* Bug fix related to codes_bsn/i_fpwet column name change giving an error on new project setups using an old swatplus_datasets.sqlite version.
* **IMPORTANT:** Time-series recall (point source/inlet) data is still not supported in this release. Please keep using version 3.2.x and do not upgrade yet if you need recall.