### PR TITLE
Revision 4.0.2

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -9,6 +9,18 @@ module.exports = {
         '@vue/eslint-config-typescript',
     ],
     rules: {
+        'indent': 'off',
+        'prefer-const': 'off',
+        '@typescript-eslint/no-explicit-any': 'off',
+        '@typescript-eslint/no-unused-vars': 'off',
+        '@typescript-eslint/no-unsafe-function-type': 'off',
+        '@typescript-eslint/no-unused-expressions': [
+            'error',
+            {
+                allowShortCircuit: true,
+                allowTernary: true,
+            },
+        ],
         'vue/multi-word-component-names': 'off',
     },
 }

--- a/changelog.md
+++ b/changelog.md
@@ -2,10 +2,15 @@
 
 ## Version 3 ##
 
+### Revision 4.0.2 ###
+
+* Bug fix affecting gfortran compiling: print plants.plt days_mat and yrs_mat as integer instead of decimals.
+* Work-around fix affecting instances where the model has an error exit code despite the model running successfully.
+* **IMPORTANT:** Time-series recall (point source/inlet) data is still not supported in this release. Please keep using version 3.2.x and do not upgrade yet if you need recall.
+
 ### Revision 4.0.1 ###
 
 * Bug fix related to codes_bsn/i_fpwet column name change giving an error on new project setups using an old swatplus_datasets.sqlite version.
-* **IMPORTANT:** Time-series recall (point source/inlet) data is still not supported in this release. Please keep using version 3.2.x and do not upgrade yet if you need recall.
 
 ### Revision 4.0.0 ###
 **IMPORTANT:** This new version of the editor is only compatible with SWAT+ rev. 62 and later. Due to structural model changes, rev. 61 and earlier are NOT supported. Project updates are available after software update.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "swatplus-editor",
-	"version": "4.0.1",
+	"version": "4.0.2",
 	"description": "SWAT+ Editor",
 	"author": "Jaclyn Tech <jaclynt@tamu.edu>",
 	"private": true,

--- a/release/build/release-notes.md
+++ b/release/build/release-notes.md
@@ -1,7 +1,12 @@
+### SWAT+ Editor 4.0.2 ###
+
+* Bug fix affecting gfortran compiling: print plants.plt days_mat and yrs_mat as integer instead of decimals.
+* Work-around fix affecting instances where the model has an error exit code despite the model running successfully.
+* **IMPORTANT:** Time-series recall (point source/inlet) data is still not supported in this release. Please keep using version 3.2.x and do not upgrade yet if you need recall.
+
 ### SWAT+ Editor 4.0.1 ###
 
 * Bug fix related to codes_bsn/i_fpwet column name change giving an error on new project setups using an old swatplus_datasets.sqlite version.
-* **IMPORTANT:** Time-series recall (point source/inlet) data is still not supported in this release. Please keep using version 3.2.x and do not upgrade yet if you need recall.
 
 ### SWAT+ Editor 4.0.0 ###
 **IMPORTANT:** This new version of the editor is only compatible with SWAT+ rev. 62 and later. Due to structural model changes, rev. 61 and earlier are NOT supported. Project updates are available after software update.

--- a/release/combined-installer-inno-arcswat.iss
+++ b/release/combined-installer-inno-arcswat.iss
@@ -22,7 +22,7 @@ AppPublisher=Texas A&M AgriLife Research
 AppPublisherURL={#SWATURL}
 AppSupportURL={#SWATURL}
 AppUpdatesURL={#SWATURL}
-OutputBaseFilename=swatplus-windows-installer-{#SWATPlusVersion}.{#SWATPlusToolsPatchVersion}
+OutputBaseFilename=swatplus-windows-installer-{#SWATPlusVersion}.{#SWATPlusToolsPatchVersion}-arcgis
 OutputDir=output
 ArchitecturesInstallIn64BitMode=x64compatible
 LicenseFile=..\license.txt
@@ -37,7 +37,6 @@ SolidCompression=yes
 WizardStyle=modern
 
 [Files]
-Source: "data\downloads\QSWATPlus_{#QSWATPlusVersion}.{#QSWATPlusPatchVersion}_Installer.exe"; DestDir: "{tmp}"; Components: qswat; 
 Source: "dist\swatplus-editor-{#SWATPlusVersion}.{#SWATPlusPatchVersion}-win32-x64.exe"; DestDir: "{tmp}"; Components: editor; 
 Source: "data\downloads\SWATPlusToolbox-v{#ToolboxVersion}.{#ToolboxPatchVersion}-win-x64-Setup.exe"; DestDir: "{tmp}"; Components: toolbox; 
 Source: "data\downloads\SWATPlus-IAHRIS_{#IahrisVersion}_Setup.exe"; DestDir: "{tmp}"; Components: iahris;  
@@ -48,8 +47,8 @@ Source: "{tmp}\swatplus_wgn.zip"; DestDir: "{tmp}"; Flags: external; ExternalSiz
 Name: "{app}\Databases"
 
 [Components]
-Name: "qswat"; Description: "QSWAT+ QGIS interface {#QSWATPlusVersion}.{#QSWATPlusPatchVersion}"; Types: typical full custom
-Name: "qswat\swatGraph"; Description: "SWATGraph tool. Not needed if you have QSWAT."; Types: typical full custom
+Name: "qswat"; Description: "ArcSWAT+ Required Files"; Types: typical full custom
+Name: "qswat\swatGraph"; Description: "SWATGraph tool"; Types: typical full custom
 Name: "qswat\manual"; Description: "QSWAT+ user manual"; Types: typical full custom
 Name: "editor"; Description: "SWAT+ Editor {#SWATPlusVersion}.{#SWATPlusPatchVersion} (includes model rev. {#ModelVersion})"; Types: typical full custom
 Name: "toolbox"; Description: "SWAT+ Toolbox {#ToolboxVersion}.{#ToolboxPatchVersion}"; Types: typical full custom
@@ -63,19 +62,18 @@ Name: "full"; Description: "Full installation"
 Name: "custom"; Description: "Custom installation"; Flags: iscustom
 
 [Files]
-Source: "data\downloads\SWATPlus\*"; DestDir: "{app}"; Excludes: "\Tools\SWATGraph, \Documents, \TauDEM539Bin"; Components: qswat; Flags: ignoreversion recursesubdirs createallsubdirs
+Source: "data\downloads\SWATPlus\*"; DestDir: "{app}"; Excludes: "\Tools\SWATGraph, \Documents"; Components: qswat; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "data\downloads\SWATPlus\Tools\SWATGraph\runSWATGraph.bat"; DestDir: "{app}\Tools\SWATGraph"; Components: qswat\swatGraph; Flags: ignoreversion recursesubdirs createallsubdirs
 Source: "data\downloads\SWATPlus\Documents\QSWATPlus Manual_v3.0.pdf"; DestDir: "{app}\Documents"; Components: qswat\manual;  Flags: ignoreversion recursesubdirs createallsubdirs
 
 [Run]
-Filename: "{tmp}\QSWATPlus_{#QSWATPlusVersion}.{#QSWATPlusPatchVersion}_Installer.exe"; Parameters: "/S {code:InstallTypeFlag}"; WorkingDir: "{tmp}"; Flags: skipifdoesntexist
 Filename: "{tmp}\swatplus-editor-{#SWATPlusVersion}.{#SWATPlusPatchVersion}-win32-x64.exe"; Parameters: "/S {code:InstallTypeFlag} /D=""{app}\SWATPlusEditor"""; WorkingDir: "{tmp}"; Flags: skipifdoesntexist
 Filename: "{tmp}\SWATPlusToolbox-v{#ToolboxVersion}.{#ToolboxPatchVersion}-win-x64-Setup.exe"; Parameters: "/S {code:TbInstallTypeFlag}"; WorkingDir: "{tmp}"; Flags: skipifdoesntexist shellexec
 Filename: "{tmp}\SWATPlus-IAHRIS_{#IahrisVersion}_Setup.exe"; Parameters: "/silent {code:TbInstallTypeFlag}"; WorkingDir: "{tmp}"; Flags: skipifdoesntexist shellexec
 
 [Messages]
-SelectDirBrowseLabel=If you select a different location from the default, you will need to set this location in the QSWAT+ Parameters form the first time you run QSWAT+.
-ConfirmUninstall=Are you sure you want to remove %1? SWAT+ Editor, SWAT+ Toolbox, tools, and documents will be removed. The QSWAT+ plugin will need to be uninstalled separately.
+SelectDirBrowseLabel=If you select a different location from the default, you will need to set this location in the ArcSWAT+ Parameters form the first time you run ArcSWAT+.
+ConfirmUninstall=Are you sure you want to remove %1? SWAT+ Editor, SWAT+ Toolbox, tools, and documents will be removed. The ArcSWAT+ plugin will need to be uninstalled separately.
 
 [UninstallRun]
 Filename: "{app}\SWATPlusEditor\Uninstall SWATPlusEditor.exe"; WorkingDir: "{app}\SWATPlusEditor"; Flags: skipifdoesntexist; RunOnceId: "SWATPlusEditor"

--- a/src/api/database/project/basin.py
+++ b/src/api/database/project/basin.py
@@ -74,7 +74,7 @@ class Parameters_bsn(base.BaseModel):
 	cov_mgt = DoubleField()
 	cha_d50 = DoubleField()
 	co2 = DoubleField()
-	day_lag_max = DoubleField()
+	day_lag_max = DoubleField() #change to int next minor version; current precision override in fileio
 	igen = IntegerField()
 
 

--- a/src/api/database/project/hru_parm_db.py
+++ b/src/api/database/project/hru_parm_db.py
@@ -6,7 +6,7 @@ class Plants_plt(base.BaseModel):
 	plnt_typ = CharField()
 	gro_trig = CharField()
 	nfix_co = DoubleField()
-	days_mat = DoubleField()
+	days_mat = DoubleField() #change to int next minor version; current precision override in fileio
 	bm_e = DoubleField()
 	harv_idx = DoubleField()
 	lai_pot = DoubleField()
@@ -39,7 +39,7 @@ class Plants_plt(base.BaseModel):
 	plnt_decomp = DoubleField()
 	lai_min = DoubleField()
 	bm_tree_acc = DoubleField()
-	yrs_mat = DoubleField()
+	yrs_mat = DoubleField() #change to int next minor version; current precision override in fileio
 	bm_tree_max = DoubleField()
 	ext_co = DoubleField()
 	leaf_tov_mn = DoubleField()

--- a/src/api/fileio/hru_parm_db.py
+++ b/src/api/fileio/hru_parm_db.py
@@ -30,7 +30,7 @@ class Plants_plt(BaseFileModel):
 		if csv:
 			self.write_default_csv(table, True)
 		else:
-			self.write_custom_query_table(table, table.select().order_by(table.name), True, format_description=True)
+			self.write_custom_query_table(table, table.select().order_by(table.name), True, format_description=True, precision_overrides={'days_mat': 0, 'yrs_mat': 0})
 
 
 class Fertilizer_frt(BaseFileModel):

--- a/src/main/static/appsettings.json
+++ b/src/main/static/appsettings.json
@@ -1,5 +1,5 @@
 {
-	"version": "4.0.1",
+	"version": "4.0.2",
 	"swatplus": "62",
 	"python": false,
 	"pythonPath": "src/api/.venv/Scripts/python"

--- a/src/main/static/swat_exe/readme.txt
+++ b/src/main/static/swat_exe/readme.txt
@@ -1,11 +1,31 @@
-By default, we typically ship SWAT+ Editor with three versions of the model: the official stable release, the latest development version, and the previous model release version.
+By default, we ship SWAT+ Editor with the official stable release.
+
 If you would like to provide your own SWAT+ model version, you may copy your executable files into this folder, then open the exe-options.csv file and add a new row with the description and file name of your custom executable.
 
 Caution: providing your own executables may cause errors if it is not compatible with the editor's default official release version. 
 Changes in input or output file formats between model versions may cause errors.
 
-Want to run the model outside of SWAT+ Editor? In this version the .dll files in this folder are required, so if you just copy and paste the .exe file, you will encounter errors if you don't have Fortran installed. 
-Instead, open a command prompt. Navigate to your TxtInOut folder (cd "C:\My-Project\Scenarios\Default\TxtInOut"), then run the SWAT exe providing the full path name. 
+--------------------------------------
+Running the Model Outside SWAT+ Editor
+--------------------------------------
 
-In the command prompt from inside your TxtInOut, type something like: "C:\Users\{YOUR_USERNAME}\SWATPlus\SWATPlusEditor\resources\app.asar.unpacked\static\swat_exe\{EXE_FILENAME_TO_RUN}.exe"
-Remember to adjust the above for your full path and SWAT exe revision number.
+If you have a static build (single executable file), you have two options:
+
+Option 1: Copy the executable
+
+1. Copy the executable file into your TxtInOut directory
+2. Open a terminal in that directory
+3. Run the executable
+
+Option 2: Run from original location
+
+1. Open a command prompt
+2. Navigate to your TxtInOut folder: 
+
+    cd "C:\My-Project\Scenarios\Default\TxtInOut"
+
+3. Run the SWAT executable with its full path:
+
+    "C:\Users\{YOUR_USERNAME}\SWATPlus\SWATPlusEditor\resources\app.asar.unpacked\static\swat_exe\{EXE_FILENAME_TO_RUN}.exe"
+
+Note: Replace {YOUR_USERNAME} and {EXE_FILENAME} with your actual username and the correct executable name.

--- a/src/renderer/views/Run.vue
+++ b/src/renderer/views/Run.vue
@@ -128,6 +128,7 @@
 			currentPids: [],
 			killMode: true,
 			hasCorrectOutput: false,
+			executionSuccessful: false
 		},
 		status: {
 			inputs: false,
@@ -248,8 +249,8 @@
 	let modelIssues:any = reactive({
 		wgn: {
 			is_invalid: false,
-			data: <any[]>[],
-			error: <string|null>null,
+			data: [] as any[],
+			error: null as string | null,
 			saving: false
 		}
 	});
@@ -404,6 +405,7 @@
 		data.page.submitted = true;
 		data.task.killMode = false;
 		data.task.hasCorrectOutput = false;
+		data.task.executionSuccessful = false;
 
 		if (noneSelected.value) {
 			data.page.saveError = 'Please select at least one task to run';
@@ -579,6 +581,11 @@
 
 		listeners.stdoutSwat = runProcess.processStdout('run-swat', (stdData:any) => {
 			let str = stdData.toString().trim();
+
+			if (str.includes("Execution successfully completed")) {
+				data.task.executionSuccessful = true;
+			}
+
 			let arr = str.split(' ').filter(function(el:any) { return el !== '' });
 			let yrIdx = arr.indexOf('Yr');
 			if (yrIdx > -1) {
@@ -610,6 +617,13 @@
 
 		listeners.stderrSwat = runProcess.processStderr('run-swat', async (stdData:any) => {
 			console.log(`stderr: ${stdData}`);
+
+			// Check if execution was already marked successful from stdout
+			if (data.task.executionSuccessful) {
+				console.log('False exit code detected.Ignoring stderr because execution completed successfully.');
+				return;
+			}
+
 			data.task.error = 'There was an error running SWAT+';
 			if (data.task.modelMessages.length > 500) data.task.modelMessages = [];
 			data.task.modelMessages.push(stdData);
@@ -1126,7 +1140,7 @@ Please check your TxtInOut/diagnostics.out file for any information, and contact
 								Stations with missing data are listed below.
 							</p>
 							<ul>
-								<li v-for="station in modelIssues.wgn.data">
+								<li v-for="(station, i) in modelIssues.wgn.data" :key="i">
 									Station <router-link class="text-warning" :to="`/edit/climate/wgn/edit/${station.id}`">{{ station.name }}</router-link> has <b>{{ station.months }}</b> months of data; 12 are required.
 								</li>
 							</ul>


### PR DESCRIPTION
* Bug fix affecting gfortran compiling: print plants.plt days_mat and yrs_mat as integer instead of decimals.
* Work-around fix affecting instances where the model has an error exit code despite the model running successfully.
* **IMPORTANT:** Time-series recall (point source/inlet) data is still not supported in this release. Please keep using version 3.2.x and do not upgrade yet if you need recall.